### PR TITLE
(Sprint 1) Generación de certificado/clave para TLS, simulación de roles y documentación

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Automatización de despliegue de un servidor web simple con seguridad TLS
+
+## Integrantes:
+
+- Daren Herrera Romo (scptx0)
+- Jhon Cruz Tairo (JECT-02)
+- Anthony Carlos Ramón (AnthonyCar243)
+
+## Instrucciones de uso
+
+## Variables de entorno
+
+## Contrato de salidas

--- a/docs/bitacora-sprint-1.md
+++ b/docs/bitacora-sprint-1.md
@@ -1,0 +1,36 @@
+# Bitacora para sprint 1
+
+- **Estudiante 1**: Jhon Cruz Tairo
+- **Estudiante 2**: Daren Herrera Romo
+- **Estudiante 3**: Anthony Carlos Ramón
+
+## Estudiante 1
+
+## Estudiante 2
+
+- Para el funcionamiento del script `generate_cert.sh` se debe definir la variable de entorno `DOMAIN`
+
+    ```bash
+    export DOMAIN=localhost # Ejemplo
+    ```
+
+    > El valor es el que será usado como CN (Common Name) en el certificado. Al menos por ahora, consideré a `localhost` como CN.
+
+- También se empleó el siguiente comando para la creación de clave y certificado:
+
+    ```bash
+    openssl req -x509 -nodes -newkey rsa:2048 \
+        -keyout "$KEY_FILE" -out "$CRT_FILE" -days 365 \
+        -subj "/CN=${DOMAIN}" > /dev/null 2>&1
+    ```
+
+    > Se genera un certificado autofirmado (`-x509`) en `CRT_FILE` (`out/certs/dominio.crt`) y la clave privada de 2048 bits en `KEY_FILE` (`out/certs/dominio.key`)
+
+**Decisiones tomadas**
+
+- Se optó por no crear usuarios reales en el sistema para garantizar reproducibilidad
+- En su lugar, se simularon roles con arrays y funciones en Bash. El resultado se almacenó en `out/sim/rol`, se simula cómo cada rol solo tiene acceso a ciertos archivos. Se consideraron dos roles: `root` y `auditor`
+- Se aplicaron permisos (con `chmod`, 600 y 644) para los archivos creados
+
+
+## Estudiante 3

--- a/docs/contrato-salidas.md
+++ b/docs/contrato-salidas.md
@@ -1,0 +1,22 @@
+# Contrato de salidas
+
+Este archivo es un listado de los artefactos generados, su formato y cómo validarlos. 
+
+## Archivos generados
+
+### Certificados y claves (out/certs/)
+- `out/certs/<dominio>.key`
+  - Formato: clave privada RSA 2048 bits.
+  - Permisos: 600.
+  - Validación: `file out/certs/<DOMAIN>.key`.
+
+- `out/certs/<dominio>.crt`
+  - Formato: certificado X.509 autofirmado.
+  - Permisos: 644.
+  - Validación: `file out/certs/<DOMAIN>.key`.
+
+### Simulación de roles (out/sim/)
+- `out/sim/root/`
+  - Contiene clave privada y certificado (simulación de acceso root).
+- `out/sim/auditor/`
+  - Contiene solo el certificado público (simulación de acceso auditor).

--- a/out/certs/localhost.crt
+++ b/out/certs/localhost.crt
@@ -1,0 +1,1 @@
+# Este archivo debe contener el certificado TLS

--- a/out/certs/localhost.key
+++ b/out/certs/localhost.key
@@ -1,0 +1,1 @@
+# Este archivo debe contener la clave privada

--- a/out/sim/auditor/localhost.crt
+++ b/out/sim/auditor/localhost.crt
@@ -1,0 +1,1 @@
+# Este archivo debe contener el certificado TLS

--- a/out/sim/root/localhost.crt
+++ b/out/sim/root/localhost.crt
@@ -1,0 +1,1 @@
+# Este archivo debe contener el certificado TLS

--- a/out/sim/root/localhost.key
+++ b/out/sim/root/localhost.key
@@ -1,0 +1,1 @@
+# Este archivo debe contener la clave privada

--- a/src/tls/generate_cert.sh
+++ b/src/tls/generate_cert.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Si no se define DOMAIN, se produce un error
+: "${DOMAIN:?Debe definir DOMAIN (ej. export DOMAIN=localhost)}"
+
+CERT_DIR="out/certs"
+SIM_ROOT="out/sim/root"
+SIM_AUDITOR="out/sim/auditor"
+
+KEY_FILE="${CERT_DIR}/${DOMAIN}.key"
+CRT_FILE="${CERT_DIR}/${DOMAIN}.crt"
+
+ROLES=("root" "auditor")
+
+# Acción del usuario root
+rol_root() {
+    echo "[root] Generando clave privada y certificado público..."
+    mkdir -p "$CERT_DIR" "$SIM_ROOT"
+
+    # Se genera el certificado público y la clave privada para la conexión TLS
+    openssl req -x509 -nodes -newkey rsa:2048 \
+      -keyout "$KEY_FILE" -out "$CRT_FILE" -days 365 \
+      -subj "/CN=${DOMAIN}" > /dev/null 2>&1
+
+    # Permisos
+    chmod 600 "$KEY_FILE"
+    chmod 644 "$CRT_FILE"
+
+    cp "$KEY_FILE" "$CRT_FILE" "$SIM_ROOT/"
+
+    echo "[root] Se generaró correctamente la clave y certificado"
+    echo "[root] Se definieron correctamente los permisos para los archivos (key=600, crt=644)"
+}
+
+# Acción del usuario auditor
+rol_auditor() {
+    echo "[auditor] Revisando el certificado público..."
+    mkdir -p "$SIM_AUDITOR"
+
+    cp "$CRT_FILE" "$SIM_AUDITOR/"
+
+    echo "[auditor] Se pudo tener acceso a el certificado público"
+}
+
+for role in "${ROLES[@]}"; do
+    case "$role" in
+        "root") rol_root ;;
+        "auditor") rol_auditor ;;
+    esac
+done


### PR DESCRIPTION
## Cambios principales
- Se agregó `src/tls/generate_cert.sh`:
  - Genera certificado X.509 autofirmado y clave RSA 2048
  - Define permisos para clave privada (600) y certificado público (644)
  - Simula roles `root` y `auditor`
  - Crea directorios en `out/sim/root` y `out/sim/auditor` para representar accesos

- Se agregó documentación:
  - `docs/bitacora-sprint-1.md`: comandos ejecutados y decisiones.
  - `docs/contrato-salidas.md`: listado de archivos generados y características.
  - `docs/README.md`: Estructura inicial de `README`

## Evidencias

Archivos generados:
- `out/certs/localhost.key`
- `out/certs/localhost.crt`

Simulación:
- `out/sim/root/` el root puede ver clave (privada) y certificado (público)
- `out/sim/auditor/` el auditor solo puede ver certificado

## Notas

- No se crean usuarios reales en el sistema porque puede afectar a la reproducibilidad