### PR TITLE
(Sprint 2) Implementación de servidor, manejo de certificados y actualización de Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 
 # Variables de entorno 
-PORT ?= 8080
+HTTP_PORT ?= 8080
+TLS_PORT ?= 8443
 MESSAGE ?= Servidor HTTP en Bash
-HOSTNAME ?= localhost
+DOMAIN ?= localhost
 
 # Carpetas
 SRC_DIR := src
@@ -48,9 +49,19 @@ test:
 		echo "No hay carpeta de tests/"; \
 	fi
 
+# Generar certificados
+generate-certs:
+	@echo "Ejecutando script para generar certificado y clave privada..."
+	@DOMAIN=$(DOMAIN) bash src/tls/generate_cert.sh
+
 # Ejecutar servidor
-run-server:
-	PORT=$(PORT) MESSAGE="$(MESSAGE)" bash src/server/server.sh
+run-http-server:
+	@PORT=$(HTTP_PORT) MESSAGE="$(MESSAGE)" bash src/server/server.sh
+
+# Ejecutar servidor TLS
+run-tls-server:
+	@echo "Ejecutando script para levantar el servidor TLS..."
+	@DOMAIN=$(DOMAIN) PORT=$(TLS_PORT) bash src/tls/tls_server.sh -www
 
 # Limpiar artefactos
 clean:
@@ -65,18 +76,28 @@ dns_check:
 	@echo "Realizando chequeo de DNS..."
 	@./src/dns/dns_check.sh
 
-# Genera todas las evidencias
-evidence:
-	@echo "Generando evidencias de HTTP y DNS..."
-	@./run_evidence.sh
-
 # Para las evidencias se ejecuta un servidor en segundo plano, luego elimina el servidor
-evidences-curl:
-	@mkdir -p out
+curl-http:
+	@mkdir -p out/http
+	@echo "Probando servidor HTTP con curl..."
 	@curl -s http://localhost:$(PORT)/ > out/curl_root.txt
 	@curl -s http://localhost:$(PORT)/bad > out/curl_404.txt
-	@cat out/curl_root.txt
-	@cat out/curl_404.txt
+	@echo "Resultados generados en out/"
+	
 
-# evidencias completas, asume que el servidor se esta ejecutando para curl
-evidences: evidences-curl
+# Para las evidencias de una conexión con el servidor TLS, se tiene que levantar el servidor primero con make run-tls-server
+curl-tls:
+	@mkdir -p out/tls
+	@echo "Probando conexión TLS con curl (ignorando validación)..."
+	@curl -sk https://$(DOMAIN):$(TLS_PORT)/ > out/tls/curl_tls_root.txt
+	@echo "Resultados generados en out/tls/curl_tls_root.txt"
+
+# Para las evidencias del handshake del cliente con el servidor TLS
+tls-handshake:
+	@mkdir -p out/tls
+	@echo "Capturando handshake con openssl s_client..."
+	@openssl s_client -connect $(DOMAIN):$(TLS_PORT) -servername $(DOMAIN) < /dev/null > out/tls/openssl_handshake.txt 2>&1
+	@echo "Resultados generados en out/tls/openssl_handshake.txt"
+
+# Evidencias completas, asume que el servidor HTTP y TLS se están ejecutando
+evidences: curl-http curl-tls tls-handshake

--- a/src/tls/generate_cert.sh
+++ b/src/tls/generate_cert.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 # Si no se define DOMAIN, se produce un error
 : "${DOMAIN:?Debe definir DOMAIN (ej. export DOMAIN=localhost)}"
 
-CERT_DIR="out/certs"
-SIM_ROOT="out/sim/root"
-SIM_AUDITOR="out/sim/auditor"
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CERT_DIR="${ROOT_DIR}/out/certs"
+SIM_ROOT="${ROOT_DIR}/out/sim/root"
+SIM_AUDITOR="${ROOT_DIR}/out/sim/auditor"
 
 KEY_FILE="${CERT_DIR}/${DOMAIN}.key"
 CRT_FILE="${CERT_DIR}/${DOMAIN}.crt"

--- a/src/tls/tls_server.sh
+++ b/src/tls/tls_server.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DOMAIN:?Debe definir DOMAIN (ej. export DOMAIN=localhost)}"
+: "${PORT:?Debe definir PORT (ej. export PORT=8443)}"
+
+trap "echo -e '\nApagando servidor TLS...'" SIGINT SIGTERM
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CERT_DIR="${ROOT_DIR}/out/certs"
+KEY_FILE="${CERT_DIR}/${DOMAIN}.key"
+CRT_FILE="${CERT_DIR}/${DOMAIN}.crt"
+
+if [[ ! -s "$CRT_FILE" || ! -s "$KEY_FILE" ]]; then
+  echo "[Error] Certificado o clave vacíos/no válidos."
+  echo "Ejecuta generate_certs.sh o make generate-certs para regenerarlos"
+  exit 1
+fi
+
+if ! openssl x509 -in "$CRT_FILE" -noout >/dev/null 2>&1; then
+  echo "[Error] El archivo de certificado $CRT_FILE no es válido."
+  exit 1
+fi
+
+if ! openssl rsa -in "$KEY_FILE" -check -noout >/dev/null 2>&1; then
+  echo "[Error] El archivo de clave privada $KEY_FILE no es válido."
+  exit 1
+fi
+
+echo "Iniciando servidor TLS en puerto $PORT..."
+openssl s_server -cert "$CRT_FILE" -key "$KEY_FILE" -accept "$PORT" -www


### PR DESCRIPTION
## Cambios principales
- Se agregó `src/tls/tls_server.sh`:
  - Levanta un servidor TLS de prueba con `openssl s_server`
  - Incluye validación de certificados y claves (archivos no vacíos y sintaxis correcta)
  - Maneja señales (SIGINT, SIGTERM) para apagado limpio

- Se actualizó el `Makefile`:
  - Nuevos targets:
    - `run-tls-server`: levanta el servidor TLS
    - `generate-certs`: genera certificado y clave privada
    - `dns_check`: ejecuta script de resolución DNS
    - `curl-tls`: evidencias de conexión TLS con `curl -k`
    - `tls-handshake`: muestra handshake con `openssl s_client`
    - `evidences` ahora incluye pruebas de HTTP y TLS
  - Eliminación de targets redundantes

## Evidencias

Archivos generados:
- `out/tls/curl_tls.txt`
- `out/tls/tls-handshake.txt`

## Notas
- Se decide usar `localhost` como dominio para evitar modificar `/etc/hosts` (debido a que se trata de resolver localmente cuando se hace `curl`)
- El certificado generado es autofirmado, por lo que se requiere `-k` en `curl` para conexión exitosa
- `ss -ltnp` puede usarse como evidencia de el socket que abre el servidor TLS (8443)