### PR TITLE
Sprint 3 Makefile-packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,23 @@ HTTP_PORT ?= 8080
 TLS_PORT ?= 8443
 MESSAGE ?= Servidor HTTP en Bash
 DOMAIN ?= localhost
+RELEASE ?= 1.0
 
 # Carpetas
 SRC_DIR := src
 OUT_DIR := out
 DIST_DIR := dist
 TEST_DIR := tests
+
+# Lista de scripts fuente
+SOURCES := $(wildcard $(SRC_DIR)/*.sh)
+OBJECTS := $(patsubst $(SRC_DIR)/%.sh,$(OUT_DIR)/%.sh,$(SOURCES))
+
+# Regla patrón: copia solo los scripts modificados a out/
+$(OUT_DIR)/%.sh: $(SRC_DIR)/%.sh
+	@mkdir -p $(OUT_DIR)
+	@cp $< $@
+	@echo "Actualizado: $@"
 
 # Mostrar ayuda
 help:
@@ -105,3 +116,10 @@ logs:
 	@journalctl --user -u servidor -n 20 --no-pager
 
 evidences: curl-http curl-tls tls-handshake
+
+pack: $(DIST_DIR)/proyecto1-$(RELEASE).tar.gz
+
+$(DIST_DIR)/proyecto1-$(RELEASE).tar.gz: $(SOURCES)
+	@mkdir -p $(DIST_DIR)
+	@tar -czf $@ $(SRC_DIR) docs
+	@echo "Paquete generado: $@"

--- a/docs/bitacora-sprint-2.md
+++ b/docs/bitacora-sprint-2.md
@@ -77,3 +77,47 @@
 - `ss -ltnp` puede emplearse como evidencia de que el servidor TLS abre un socket en el puerto 8443
 
 ## Estudiante 3
+
+- Creación de unidad systemd/servidor.service
+
+  Se definió el archivo de servicio en `~/.config/systemd/user/servidor.service`
+
+- Se recargó el demonio de systemd y se activó el servicio, con los comandos:
+
+  ```
+	systemctl --user daemon-reload
+    systemctl --user enable servidor
+    systemctl --user start servidor
+  ```
+  Se verifica el estado con el comando:
+   
+  ```
+	systemctl --user status servidor
+  ```
+  Salida relevante:
+  ```
+	Active: active (running)
+    Main PID: 1234 (bash)
+  ```
+
+- Ampliación del Makefile con `make logs`
+
+  Se añadió el siguiente target al Makefile:
+
+  ```
+	logs:
+	@echo "Mostrando logs del servicio servidor..."
+	@journalctl --user -u servidor -n 20 --no-pager
+  ```
+
+  Salida:
+  ```
+	Mostrando logs del servicio servidor...
+    Servidor HTTP en Bash iniciado en puerto 8080
+  ```
+
+**Decisiones tomadas**
+
+- Se integró `systemd` para gestionar el servidor como servicio en segundo plano.
+- Se documentó y facilitó el acceso a registros con `journalctl` y el nuevo target make logs.
+


### PR DESCRIPTION
## Cambios principales

- Se añadieron reglas patrón al Makefile para soportar incremental build, evitando copias innecesarias de archivos no modificados.
- Se creó el target pack que genera un archivo comprimido dist/proyecto1-${RELEASE}.tar.gz con los scripts y documentación del proyecto.

## Evidencias

- Ejecución de make out/servidor.sh muestra actualización solo cuando hay cambios en src/servidor.sh.
- Ejecución de make pack RELEASE=1.2 genera correctamente dist/proyecto1-1.2.tar.gz.

## Notas
- Se definió la variable RELEASE con valor por defecto 1.0, pero puede ser sobreescrita al invocar make.